### PR TITLE
Update date picker code

### DIFF
--- a/google-photos-tz-fix.js
+++ b/google-photos-tz-fix.js
@@ -216,12 +216,12 @@
                                 })
                                 .done(function() {
                                     setTimeout(function() {
-                                        $(dialog).find(FIELD_TZ).filter(':contains("' + EXPECTED_TZ + '")').click();
+                                        $(dialog).find(FIELD_TZ).filter(':contains("' + EXPECTED_TZ + '")').last().click();
                                     }, rand(800, 500));
                                 });
                         },
                         verify: function() {
-                            return ($(dialog).find(FIELD_TZ).attr('aria-label') || '').indexOf(EXPECTED_TZ) !== -1;
+                            return ($(dialog).find(FIELD_TZ).filter('[aria-selected="true"]').attr('aria-label') || '').indexOf(EXPECTED_TZ) !== -1;
                         },
                         value: EXPECTED_TZ
                     },


### PR DESCRIPTION
Fixes the script to work on the current versions of Google Photos.

The two problems were:
 - When a new timezone is selected, the dropdown field was not updated
 - The script failed to verify the current timezone