### PR TITLE
Add option to set timezone without changing the time for photos not following naming pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Both workarounds are not ideal which led me to implement this script which fixes
 
 ## prerequisites
 - you need to edit script and set `EXPECTED_TZ` to desired timezone
-- your photos needs to follow naming pattern `YYYYMMDD-HHMMSS-NR`, for example: `20170414-204918-2042.jpg`
+- your photos needs to follow naming pattern `YYYYMMDD-HHMMSS-NR` or `YYYYMMDD_HHMMSS`, for example:
+`20170414-204918-2042.jpg`, `20170414_204918.JPG` or `20170414_204918-2.DNG`
 - you need to install *Tampermonkey* plugin in your browser (only Chrome was tested)
 
 ## how it works

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Both workarounds are not ideal which led me to implement this script which fixes
 - you need to edit script and set `EXPECTED_TZ` to desired timezone
 - your photos needs to follow naming pattern `YYYYMMDD-HHMMSS-NR` or `YYYYMMDD_HHMMSS`, for example:
 `20170414-204918-2042.jpg`, `20170414_204918.JPG` or `20170414_204918-2.DNG`
+(there is an option to change timezone without changing time for photos that do not follow the pattern, see `SET_JUST_TZ_FOR_IMPROPERLY_NAMED`)
 - you need to install *Tampermonkey* plugin in your browser (only Chrome was tested)
 
 ## how it works
@@ -32,6 +33,7 @@ Both workarounds are not ideal which led me to implement this script which fixes
 
 ## how to use it
 - open *Tampermonkey* options and add google-photos-timezone-fix script
+- set `EXPECTED_TZ` in script to desired timezone
 - navigate to https://photos.google.com/ and open album which you want to edit
 - open first photo and open photo details sidebar by clicking "info" icon
 - open browser console and type

--- a/google-photos-tz-fix.js
+++ b/google-photos-tz-fix.js
@@ -38,7 +38,7 @@
         return from + Math.floor(Math.random() * plus);
     }
 
-    function waitFor(deadline, task, condition) {
+    function waitFor(name, deadline, task, condition) {
         if (new Date().getTime() > deadline) {
             task.reject();
             return;
@@ -47,8 +47,8 @@
         if (condition()) {
             setTimeout(task.resolve, rand(200, 150));
         } else {
-            notify(' ', 'waiting...');
-            requestAnimationFrame(waitFor.bind(null, deadline, task, condition));
+            notify(' ', 'waiting...' + name);
+            requestAnimationFrame(waitFor.bind(null, name, deadline, task, condition));
         }
     }
 
@@ -63,7 +63,7 @@
             var previousOffsets = [];
             var compareLast = 5;
 
-            waitFor(new Date().getTime() + dialogTimeout, task, function() {
+            waitFor("Dialog appeared", new Date().getTime() + dialogTimeout, task, function() {
                 var dialog = $('[role="dialog"]:visible');
                 var fields = [ FIELD_HOUR, FIELD_MINUTES, FIELD_AMPM, FIELD_YEAR, FIELD_MONTH, FIELD_DAY ];
                 var fieldsPopulated = fields.every(item => !!dialog.find(item).val());
@@ -100,7 +100,7 @@
             if (needToSave) {
                 var progress = '';
 
-                waitFor(new Date().getTime() + savingTimeout, task, function() {
+                waitFor("Date changed notification", new Date().getTime() + savingTimeout, task, function() {
                     var notification = $(':contains("Date changed"):visible:last');
                     var position = notification.position() || { top: -1 };
                     var state = (position.top > 0) ? '1' : '0';
@@ -118,7 +118,7 @@
 
                 setTimeout(function() { cancelButton.click(); }, rand(500, 150));
 
-                waitFor(new Date().getTime() + dialogTimeout, task, function() {
+                waitFor("Dialog disappears", new Date().getTime() + dialogTimeout, task, function() {
                     return $('[role="dialog"]:visible').length === 0;
                 });
             }
@@ -157,7 +157,7 @@
             if (needToUpdate) {
                 needToSave = true;
 
-                waitFor(new Date().getTime() + updateTimeout, updater, function() {
+                waitFor("Dialog updated", new Date().getTime() + updateTimeout, updater, function() {
                     var valueUpdated;
                     var formUpdated = previousValues !== fieldDump(watchedFields);
                     var captionUpdated = caption !== dialog.find(':contains("Edit date & time"):last').text();
@@ -206,7 +206,7 @@
 
                             $(dialog).find(FIELD_TZ).closest('[role="presentation"]').click();
 
-                            waitFor(new Date().getTime() + updateTimeout, updater, function() {
+                            waitFor("find TZ field", new Date().getTime() + updateTimeout, updater, function() {
                                 return $(dialog).find(FIELD_TZ).length > 1;
                             });
 
@@ -339,7 +339,7 @@
         if (button.length) {
             setTimeout(function() { button.click(); }, rand(500, 150));
 
-            waitFor(new Date().getTime() + nextPhotoTimeout, task, function() {
+            waitFor("next photo loaded", new Date().getTime() + nextPhotoTimeout, task, function() {
                 var current = getPhotoDetails();
 
                 return previous && current && (previous.filename !== current.filename);

--- a/google-photos-tz-fix.js
+++ b/google-photos-tz-fix.js
@@ -103,7 +103,8 @@
                 waitFor("Date changed notification", new Date().getTime() + savingTimeout, task, function() {
                     var notification = $(':contains("Date changed"):visible:last');
                     var position = notification.position() || { top: -1 };
-                    var state = (position.top > 0) ? '1' : '0';
+                    var positionTop = position.top;
+                    var state = (positionTop >= 0) ? '1' : '0';
 
                     progress += (progress.slice(-1) === state) ? '' : state;
 

--- a/google-photos-tz-fix.js
+++ b/google-photos-tz-fix.js
@@ -21,7 +21,7 @@
     var savingTimeout = 10 * 1000;
     var dialogTimeout = 3 * 1000;
 
-    var FILENAME_PATTERN = new RegExp(/^[0-9]{8}-[0-9]{6}-/);
+    var FILENAME_PATTERN = new RegExp(/^[0-9]{8}[-_][0-9]{6}[-_.]/);
     var FIELD_TZ = '[data-value][aria-hidden!="true"]';
     var FIELD_HOUR = 'input[aria-label="Hour"]';
     var FIELD_MINUTES = 'input[aria-label="Minutes"]';
@@ -294,7 +294,7 @@
         }
 
         if (info.length) {
-            var chunks = info.split(/-/);
+            var chunks = info.split(/[-_]/);
             var date = chunks.shift();
             var time = chunks.shift();
 


### PR DESCRIPTION
I use the script to fix time and restore chronological order for photos from different cameras (including android and DSLR).
1. My android phone uses another naming convention which is rather popular (names like 20230506_120000.jpg or 20230506_120000-1.jpg).
2. Photos from DSLR camera do not include time in their filenames, but the problem with timezone is also actual for those photos. Google correctly takes the time from image metadata, so only timezone should be corrected. I added an option to set timezone for photos which do not have timezone already set.